### PR TITLE
Remove warning and make icons work

### DIFF
--- a/filemanager.php
+++ b/filemanager.php
@@ -53,7 +53,7 @@ if (defined('FM_EMBED')) {
     $use_auth = false;
 } else {
     error_reporting(E_ALL);
-    set_time_limit(600);
+    @set_time_limit(600);
 
     date_default_timezone_set($default_timezone);
 


### PR DESCRIPTION
On shared hostings this function is usually disabled so it shows a pesky warning and breaks all the images.