### PR TITLE
Remove unwanted characters from new folder names

### DIFF
--- a/filemanager.php
+++ b/filemanager.php
@@ -181,7 +181,7 @@ if (isset($_GET['del'])) {
 
 // Create folder
 if (isset($_GET['new'])) {
-    $new = $_GET['new'];
+    $new = strip_tags($_GET['new']); // remove unwanted characters from folder name
     $new = fm_clean_path($new);
     $new = str_replace('/', '', $new);
     if ($new != '' && $new != '..' && $new != '.') {


### PR DESCRIPTION
Used ```strip_tags()``` function to remove unwanted characters from new folder names. Without this, the user can enter anything, i.e. ```<h3>New Folder</h3>``` (mentioned by a user in issues) and this breaks the CSS of the table. Now with ```strip_tgs()``` we will allow only safe names by removing unwanted HTML tags that would break the styling.